### PR TITLE
fix deprecations

### DIFF
--- a/addon/initializers/pagefront-beacon.js
+++ b/addon/initializers/pagefront-beacon.js
@@ -1,4 +1,5 @@
-export function initialize(container, application) {
+export function initialize() {
+  let application = arguments[1] || arguments[0];
   application.inject('service:pagefront-beacon', 'target', 'route:application');
 }
 

--- a/addon/instance-initializers/pagefront-beacon.js
+++ b/addon/instance-initializers/pagefront-beacon.js
@@ -9,17 +9,15 @@ function hasAction(route) {
   return actions && Ember.typeOf(actions[ACTION]) === FUNCTION;
 }
 
-function isEnabled(container) {
-  const route = container.lookup('route:application');
+function isEnabled(applicationInstance) {
+  const route = applicationInstance.lookup('route:application');
 
   return route && hasAction(route);
 }
 
 export function initialize(applicationInstance) {
-  const container = applicationInstance.container;
-
-  if (isEnabled(container)) {
-    container.lookup('service:pagefront-beacon');
+  if (isEnabled(applicationInstance)) {
+    applicationInstance.lookup('service:pagefront-beacon');
   }
 }
 


### PR DESCRIPTION
There are few deprecated calls happening in the initializers. I've tried to use the recommended ways to keep them backwards compatible.

http://emberjs.com/deprecations/v2.x/#toc_initializer-arity
http://emberjs.com/deprecations/v2.x/#toc_ember-applicationinstance-container

Thanks!
