### PR TITLE
Fix availableOptions warnings:

### DIFF
--- a/lib/commands/login.js
+++ b/lib/commands/login.js
@@ -74,6 +74,10 @@ module.exports = {
   name: 'login',
   description: 'Log in to Pagefront',
   works: 'insideProject',
+  availableOptions: [
+    { name: 'app', type: String, default: false, aliases: ['a'] },
+    { name: 'key', type: String, default: false, aliases: ['k'] }
+  ],
 
   run: function() {
     return collectCredentials()


### PR DESCRIPTION
Quick fix here:

```bash
ember install ember-pagefront --app=foo --key=abc-123
The option "--app" is not registered with the hello command. Run "ember install --help" for a list of supported options.
The option "--key" is not registered with the hello command. Run "ember install --help" for a list of supported options.
```