### PR TITLE
Update ember-cli-babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "chalk": "^1.1.1",
-    "ember-cli-babel": "^5.1.3",
+    "ember-cli-babel": "^6.8.2",
     "ember-cli-deploy-build": "0.1.0",
     "ember-cli-deploy-display-revisions": "0.1.0",
     "ember-cli-deploy-gzip": "pagefront/ember-cli-deploy-gzip#0a98e80768d089ea6488b36f2c9a79f95067d71d",


### PR DESCRIPTION
The reason for this update is that we need to update the entire addon community to babel6 in order to get the new modules that will eventually lead to tree shaking.

Alternatively, the addon could remain in 5.X as long as the runtime code in initializers and instance-initializers is deleted.